### PR TITLE
collection: Added a statsGetter type which wraps the mgo.Session.

### DIFF
--- a/collection_size.go
+++ b/collection_size.go
@@ -5,7 +5,9 @@ package monitoring
 
 import (
 	"fmt"
+	"sync"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/mgo.v2"
@@ -13,8 +15,62 @@ import (
 )
 
 var (
-	log = loggo.GetLogger("collectors")
+	log = loggo.GetLogger("monitoring.collectors")
 )
+
+type stats struct {
+	Count int32 `bson:"count"`
+	Size  int32 `bson:"size"`
+}
+
+type statsGetter struct {
+	lock    sync.Mutex
+	session *mgo.Session
+	closed  bool
+}
+
+// NewStatsGetter returns a new new statsGetter used for
+// getting Count and Size information about a collection
+// and closing the session.
+func NewStatsGetter(s *mgo.Session) *statsGetter {
+	return &statsGetter{
+		session: s,
+	}
+}
+
+// Get returns the Count and Size information of the given collection.
+// If the underlying session is already closed it returns an error.
+func (s *statsGetter) Get(db, coll string) (st stats, err error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.closed {
+		return st, errors.New("session is closed")
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			s.closed = true
+			log.Warningf("recovered from panic: %v", r)
+			err = errors.New("session is closed")
+		}
+	}()
+	session := s.session.Copy()
+	defer session.Close()
+
+	collection := session.DB(db).C(coll)
+	err = collection.Database.Run(bson.M{"collStats": collection.Name}, &st)
+	if err != nil {
+		return st, errors.Trace(err)
+	}
+	return st, nil
+}
+
+// Close closes the underlying mgo session.
+func (s *statsGetter) Close() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.session.Close()
+	s.closed = true
+}
 
 // CollectionSizeCollector implements the prometheus.Collector interface and
 // reports the size of the specified mongo collection.
@@ -22,13 +78,13 @@ type CollectionSizeCollector struct {
 	sizeDesc  *prometheus.Desc
 	countDesc *prometheus.Desc
 
-	session        *mgo.Session
+	statsGetter    *statsGetter
 	database       string
 	collectionName string
 }
 
 // NewCollectionSizeCollector returns a new collection size collector with specified properties.
-func NewCollectionSizeCollector(namespace, subsystem, namePrefix, database, collectionName string, s *mgo.Session) *CollectionSizeCollector {
+func NewCollectionSizeCollector(namespace, subsystem, namePrefix, database, collectionName string, getter *statsGetter) *CollectionSizeCollector {
 	return &CollectionSizeCollector{
 		sizeDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, subsystem, fmt.Sprintf("%s_collection_size_bytes", namePrefix)),
@@ -40,9 +96,9 @@ func NewCollectionSizeCollector(namespace, subsystem, namePrefix, database, coll
 			fmt.Sprintf("%v collection object count", collectionName),
 			nil,
 			nil),
-		session:        s,
 		database:       database,
 		collectionName: collectionName,
+		statsGetter:    getter,
 	}
 }
 
@@ -54,28 +110,20 @@ func (u *CollectionSizeCollector) Describe(c chan<- *prometheus.Desc) {
 
 // Collect implements the prometheus.Collector interface.
 func (u *CollectionSizeCollector) Collect(ch chan<- prometheus.Metric) {
-	session := u.session.Copy()
-	defer session.Close()
-
-	collection := session.DB(u.database).C(u.collectionName)
-	var stats struct {
-		Count int32 `bson:"count"`
-		Size  int32 `bson:"size"`
-	}
-	err := collection.Database.Run(bson.M{"collStats": collection.Name}, &stats)
+	stats, err := u.statsGetter.Get(u.database, u.collectionName)
 	if err != nil {
-		log.Errorf("failed to report %v collection stats: %v", collection.Name, err)
+		log.Errorf("failed to report %v collection stats: %v", u.collectionName, err)
 		return
 	}
 
 	mSize, err := prometheus.NewConstMetric(u.sizeDesc, prometheus.GaugeValue, float64(stats.Size))
 	if err != nil {
-		log.Errorf("failed to report %v collection stats: %v", collection.Name, err)
+		log.Errorf("failed to report %v collection stats: %v", u.collectionName, err)
 		return
 	}
 	mCount, err := prometheus.NewConstMetric(u.countDesc, prometheus.GaugeValue, float64(stats.Count))
 	if err != nil {
-		log.Errorf("failed to report %v collection stats: %v", collection.Name, err)
+		log.Errorf("failed to report %v collection stats: %v", u.collectionName, err)
 		return
 	}
 	ch <- mSize


### PR DESCRIPTION
This allows the creator of the monitor to maintain control over
the session even when the monoitor is registered with prometheus.
