### PR TITLE
use postgrestest not pgtest

### DIFF
--- a/collection_size_test.go
+++ b/collection_size_test.go
@@ -106,7 +106,7 @@ func getValue(c *gc.C, ch chan prometheus.Metric, label string) float64 {
 	select {
 	case m = <-ch:
 	default:
-		c.Error("metric not provided by collector")
+		c.Fatal("metric not provided by collector")
 	}
 
 	err := m.Write(&raw)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,9 +1,9 @@
-github.com/CanonicalLtd/omniutils	git	21046a7139106a59ab32b81fd4e70754cf67acba	2018-09-10T13:23:49Z
 github.com/beorn7/perks	git	3ac7bf7a47d159a033b107610db8a1b6575507a4	2016-02-29T21:34:45Z
 github.com/gogo/protobuf	git	5669497fd64452f28d142899eeb1bfd7e8b26ac8	2018-08-30T16:04:56Z
 github.com/golang/protobuf	git	4bd1920723d7b7c925de087aa32e2187708897f7	2016-11-09T07:27:36Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/loggo	git	8232ab8918d91c72af1a9fb94d3edbe31d88b790	2017-06-05T01:46:07Z
+github.com/juju/postgrestest	git	95c1ddb2775d334cd3011baf1639f72ee497a288	2018-01-11T15:03:07Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/testing	git	799dbfe87f1a3c7fec5ab5638302b3bf853acee5	2018-01-15T00:53:07Z
 github.com/juju/utils	git	9b65c33e54c793d74a4ed99c15111c44faddb8e4	2017-10-25T16:38:56Z
@@ -17,5 +17,6 @@ github.com/prometheus/procfs	git	abf152e5f3e97f2fafac028d2cc06c1feb87ffa5	2016-0
 golang.org/x/crypto	git	96846453c37f0876340a66a47f3f75b1f3a6cd2d	2017-04-21T04:31:20Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
+gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
 gopkg.in/mgo.v2	git	f2b6f6c918c452ad107eec89615f074e3bd80e33	2016-08-18T01:52:18Z
 gopkg.in/yaml.v2	git	1be3d31502d6eabc0dd7ce5b0daab022e14a5538	2017-07-12T05:45:46Z

--- a/table_size_test.go
+++ b/table_size_test.go
@@ -4,9 +4,7 @@
 package monitoring_test
 
 import (
-	"database/sql"
-
-	"github.com/CanonicalLtd/omniutils/testing/pgtest"
+	"github.com/juju/postgrestest"
 	jc "github.com/juju/testing/checkers"
 	"github.com/prometheus/client_golang/prometheus"
 	gc "gopkg.in/check.v1"
@@ -17,14 +15,11 @@ import (
 var _ = gc.Suite(&tableSizeSuite{})
 
 type tableSizeSuite struct {
-	pgtest.PGSuite
-	db *sql.DB
+	db *postgrestest.DB
 }
 
 func (s *tableSizeSuite) SetUpTest(c *gc.C) {
-	s.PGSuite.SetUpTest(c)
-
-	db, err := sql.Open("postgres", s.URL)
+	db, err := postgrestest.New()
 	c.Assert(err, jc.ErrorIsNil)
 	s.db = db
 
@@ -39,8 +34,15 @@ func (s *tableSizeSuite) SetUpTest(c *gc.C) {
 	}
 }
 
+func (s *tableSizeSuite) TearDownTest(c *gc.C) {
+	if s.db != nil {
+		s.db.Close()
+		s.db = nil
+	}
+}
+
 func (s *tableSizeSuite) TestCollector(c *gc.C) {
-	m, err := monitoring.NewTableSizeCollector("test", s.db)
+	m, err := monitoring.NewTableSizeCollector("test", s.db.DB)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ch := make(chan prometheus.Metric, 10)


### PR DESCRIPTION
The pgtest package is in a private repository which
should not be imported from a public repository.

As postgrestest does not create a new database
for each test, we change NewTableSizeCollector
so that it queries the current schema instead of assuming
that it is "public".